### PR TITLE
Add MIT License with Commons Clause and update README.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+MIT License
+
+Copyright (c) 2025 Gabriel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+Commons Clause Restriction:
+The Software is provided under the terms of the MIT license, with the following
+Commons Clause restriction added:
+
+**“The Software may not be used in connection with any commercial purpose, including without limitation: selling, charging for access, providing paid support, or using the Software as part of a paid service, without prior written permission from the copyright holder.”**
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -150,4 +150,8 @@ Contribuições são bem-vindas! Sinta-se à vontade para abrir issues ou pull r
 
 ## Licença
 
-Este projeto está licenciado sob a [Licença MIT com Commons Clause](https://commonsclause.com/).
+Este projeto está licenciado sob a [Licença MIT com Commons Clause](https://commonsclause.com/). A Commons Clause adiciona restrições ao uso comercial do software. Para mais detalhes, consulte o arquivo [LICENSE](./LICENSE).
+
+### Nota para Contribuidores
+
+Contribuidores devem estar cientes de que a Commons Clause restringe o uso comercial do software, mesmo que ele seja baseado na Licença MIT. Certifique-se de entender essas implicações antes de contribuir.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # LivePix React SDK
 
+[![License: MIT + Commons Clause](https://img.shields.io/badge/license-MIT--Commons%20Clause-blue.svg)](./LICENSE)
+[![Issues](https://img.shields.io/github/issues/ApenasGabs/livepix-react-sdk)](https://github.com/ApenasGabs/livepix-react-sdk/issues)
+[![Stars](https://img.shields.io/github/stars/ApenasGabs/livepix-react-sdk?style=social)](https://github.com/ApenasGabs/livepix-react-sdk/stargazers)
+[![Forks](https://img.shields.io/github/forks/ApenasGabs/livepix-react-sdk?style=social)](https://github.com/ApenasGabs/livepix-react-sdk/network/members)
+[![Contributors](https://img.shields.io/github/contributors/ApenasGabs/livepix-react-sdk)](https://github.com/ApenasGabs/livepix-react-sdk/graphs/contributors)
+[![LivePix - Apoie este projeto](https://img.shields.io/badge/💖%20Apoie-via%20LivePix-ff69b4?style=flat-square)](https://livepix.gg/apenasgabs)
+
 ## Introdução
 
 O LivePix React SDK é uma biblioteca que facilita a interação com a API LivePix, permitindo que desenvolvedores integrem funcionalidades de forma simples e eficiente em suas aplicações React. Este SDK inclui componentes React, hooks personalizados e utilitários para gerenciar autenticação e requisições à API.
@@ -143,4 +150,4 @@ Contribuições são bem-vindas! Sinta-se à vontade para abrir issues ou pull r
 
 ## Licença
 
-Este projeto está licenciado sob a licença MIT.
+Este projeto está licenciado sob a [Licença MIT com Commons Clause](https://commonsclause.com/).

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "livepix",
     "api"
   ],
-  "author": "Your Name",
+  "author":"Gabriel Rordrigues",
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "axios": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "api"
   ],
   "author": "Your Name",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "axios": "^1.6.0",
     "react": "^18.0.0",


### PR DESCRIPTION
Introduce the MIT License with Commons Clause to clarify commercial usage restrictions. Update the README to reflect the new license and inform contributors about the implications of the Commons Clause.